### PR TITLE
chore: Add debug output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh -l
 
-POLICY_BREACHES=`curio scan $* .`
+# N.B. Expect to be running in `/github/workspace`
+printf "DEBUG: Running in working directory: %s\n" `pwd`
+
+POLICY_BREACHES=`curio scan --debug $* .`
 SCAN_EXIT_CODE=$?
 
 [ $SCAN_EXIT_CODE -eq 0 ] || echo "policy-breaches=$POLICY_BREACHES" >>$GITHUB_OUTPUT


### PR DESCRIPTION
In particular, we want to know what is the current working directory for the `curio` invocation within the container.