### PR TITLE
fix: Output parameter naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run [Curio](https://curio.sh/) as a [GitHub Action](https://github.com/features/
 
 ## Outputs
 
-### `policy-breaches`
+### `policy_breaches`
 
 Details of any policy breaches that occur
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ''
 outputs:
-  policy-breaches:
+  policy_breaches:
     description: 'Details of any policy breaches that occur'
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,6 @@
 POLICY_BREACHES=`curio scan $* .`
 SCAN_EXIT_CODE=$?
 
-[ $SCAN_EXIT_CODE -eq 0 ] || echo "policy-breaches=$POLICY_BREACHES" >>$GITHUB_OUTPUT
+[ $SCAN_EXIT_CODE -eq 0 ] || echo "policy_breaches=$POLICY_BREACHES" >>$GITHUB_OUTPUT
 
 exit $SCAN_EXIT_CODE


### PR DESCRIPTION
Output parameter names can only contain alphanumeric characters plus underscores -- not dashes.