### PR TITLE
chorefix: Investigate failure to set action output parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,8 @@ inputs:
     required: false
     default: ''
 outputs:
+  time:
+    description: 'The time'
   policy_breaches:
     description: 'Details of any policy breaches that occur'
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/sh -l
 
-POLICY_BREACHES=`curio scan $* .`
+POLICY_BREACHES=`curio scan --quiet $* .`
 SCAN_EXIT_CODE=$?
 
-[ $SCAN_EXIT_CODE -eq 0 ] || echo "policy_breaches=$POLICY_BREACHES" >>$GITHUB_OUTPUT
+# @todo FIXME:
+# [ $SCAN_EXIT_CODE -eq 0 ] || echo "policy_breaches=$POLICY_BREACHES" >>$GITHUB_OUTPUT
+
+time=`date`
+echo "time=$time" >> $GITHUB_OUTPUT
 
 exit $SCAN_EXIT_CODE


### PR DESCRIPTION
Temporarily introduce a `time` output parameter, which is simpler than our intended use case. If this simpler use case also fails, then we can deduce that there may be a wider issue.